### PR TITLE
Fixes for renamed repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in tanzu-application-platform-reference-packages project and our
+We as members, contributors, and leaders pledge to make participation in tanzu-application-platform-reference-service-packages project and our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to tanzu-application-platform-reference-packages
+# Contributing to tanzu-application-platform-reference-service-packages
 
-The tanzu-application-platform-reference-packages project team welcomes contributions from the community. Before you start working with this project please read and sign our Contributor License Agreement (https://cla.vmware.com/cla/1/preview). If you wish to contribute code and you have not signed our Contributor Licence Agreement (CLA), our bot will prompt you to do so when you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
+The tanzu-application-platform-reference-service-packages project team welcomes contributions from the community. Before you start working with this project please read and sign our Contributor License Agreement (https://cla.vmware.com/cla/1/preview). If you wish to contribute code and you have not signed our Contributor Licence Agreement (CLA), our bot will prompt you to do so when you open a Pull Request. For any questions about the CLA process, please refer to our [FAQ](https://cla.vmware.com/faq).
 
 ## Contribution Flow
 
@@ -15,7 +15,7 @@ This is a rough outline of what a contributor's workflow looks like:
 Example:
 
 ``` shell
-git remote add upstream https://github.com/vmware-tanzu/tanzu-application-platform-reference-packages.git
+git remote add upstream https://github.com/vmware-tanzu/tanzu-application-platform-reference-service-packages.git
 git checkout -b my-new-feature main
 git commit -a
 git push origin my-new-feature

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ These reference packages are compatible with the following:
 Add the PackageRepository to your Kubernetes cluster:
 
 ```shell
-tanzu package repository add tap-service-reference-packages \
-    --url ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/tap-service-reference-package-repo:0.0.2 \
+tanzu package repository add tap-reference-service-packages \
+    --url ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages:0.0.2 \
     -n tanzu-package-repo-global
 ```
 
@@ -50,11 +50,11 @@ Follow the instructions for a specific Service Instance below:
 To publish a new Package Repository follow these instructions:
 
 ```shell
-export REPO_HOST=ghcr.io/tanzu-application-platform-reference-packages
+export REPO_HOST=ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages
 export TAG=0.0.1-build.1
 
 kbld -f repository/ --imgpkg-lock-output repository/.imgpkg/images.yml
-imgpkg push -b ${REPO_HOST}/tap-service-reference-package-repo:${TAG} -f repository
+imgpkg push -b ${REPO_HOST}:${TAG} -f repository
 ```
 
 ## Adding a new Service Instance Package Bundle to the Repository
@@ -63,7 +63,7 @@ imgpkg push -b ${REPO_HOST}/tap-service-reference-package-repo:${TAG} -f reposit
 
 ## Contributing
 
-The tanzu-application-platform-reference-packages project team welcomes contributions from the community. Before you start working with this project please
+The tanzu-application-platform-reference-service-packages project team welcomes contributions from the community. Before you start working with this project please
 read and sign our Contributor License Agreement (https://cla.vmware.com/cla/1/preview). If you wish to contribute code and you have not signed our
 Contributor Licence Agreement (CLA), our bot will prompt you to do so when you open a Pull Request. For more detailed information, refer to 
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/bundles/amazon/ack/rds/README.md
+++ b/bundles/amazon/ack/rds/README.md
@@ -22,7 +22,7 @@ To alter this Package, modify the contents and perform the following steps to bu
 1. Build a new Package bundle image:
 
 ```
-export REPO_HOST=<YOUR_IMAGE_REPO> #! e.g. ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages
+export REPO_HOST=<YOUR_IMAGE_REPO> #! e.g. ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages
 export BUNDLE_TAG=<YOUR_BUNDLE_TAG> #! e.g. latest
 
 pushd bundle

--- a/packagerepo.yaml
+++ b/packagerepo.yaml
@@ -2,9 +2,9 @@
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageRepository
 metadata:
-  name: tap-service-reference-packages
+  name: tap-reference-service-packages
   namespace: tanzu-package-repo-global #! note this may be different in kapp was not installed through cluster-essentials
 spec:
   fetch:
     imgpkgBundle:
-      image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/tap-service-reference-package-repo:0.0.2
+      image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages:0.0.2

--- a/repository/.imgpkg/images.yml
+++ b/repository/.imgpkg/images.yml
@@ -2,12 +2,9 @@
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
 - annotations:
-    kbld.carvel.dev/id: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
-    kbld.carvel.dev/origins: |
-      - preresolved:
-          url: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
-  image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
+    kbld.carvel.dev/id: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
+  image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
 - annotations:
-    kbld.carvel.dev/id: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
-  image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
+    kbld.carvel.dev/id: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
+  image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
 kind: ImagesLock

--- a/repository/packages/amazon/rds/package.yaml
+++ b/repository/packages/amazon/rds/package.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
+          image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.aws.references.services.apps.tanzu.vmware.com@sha256:01481af67e9be08c466e7d98eb1e2e0e904a4965d289d793c41d316aeef59332
       template:
       - ytt:
           paths:

--- a/repository/packages/google/cloudsql/package.yaml
+++ b/repository/packages/google/cloudsql/package.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       fetch:
       - imgpkgBundle:
-          image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
+          image: ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.google.references.services.apps.tanzu.vmware.com@sha256:9fc1a2767adac504e06d6eb8c9b2cbecc887ad605e3652401f26dc101abd1c6d
       template:
       - ytt:
           paths:


### PR DESCRIPTION
* Also simplify the location of our Package Repository bundle to simply ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages:tag

New PackageRepository lives at:
```
ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages:0.0.2
```

And contains references to:
```
ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.aws.references.services.apps.tanzu.vmware.com
ghcr.io/vmware-tanzu/tanzu-application-platform-reference-service-packages/psql.google.references.services.apps.tanzu.vmware.com
```

closes #16